### PR TITLE
refactor rounds map into a list of lists

### DIFF
--- a/backend/src/main/java/in/kahl/promptwhispers/model/Turn.java
+++ b/backend/src/main/java/in/kahl/promptwhispers/model/Turn.java
@@ -16,19 +16,11 @@ public record Turn(
         String content,
         Instant createdAt
 ) {
-    public Turn(TurnType type, String content) {
-        this(null, type, content);
-    }
-
     public Turn(User player, TurnType type, String content) {
         this(UUID.randomUUID().toString(),
                 player,
                 type,
                 content,
                 Instant.now().truncatedTo(ChronoUnit.MILLIS));
-    }
-
-    public Turn withPlayer(User player) {
-        return new Turn(id(), player, type(), content(), createdAt());
     }
 }

--- a/backend/src/main/java/in/kahl/promptwhispers/model/dto/PromptCreate.java
+++ b/backend/src/main/java/in/kahl/promptwhispers/model/dto/PromptCreate.java
@@ -2,11 +2,12 @@ package in.kahl.promptwhispers.model.dto;
 
 import in.kahl.promptwhispers.model.Turn;
 import in.kahl.promptwhispers.model.TurnType;
+import in.kahl.promptwhispers.model.User;
 
 public record PromptCreate(
         String prompt
 ) {
-    public Turn asNewPromptTurn() {
-        return new Turn(TurnType.PROMPT, prompt());
+    public Turn asNewPromptTurn(User player) {
+        return new Turn(player, TurnType.PROMPT, prompt());
     }
 }

--- a/backend/src/main/java/in/kahl/promptwhispers/service/GameService.java
+++ b/backend/src/main/java/in/kahl/promptwhispers/service/GameService.java
@@ -40,7 +40,7 @@ public class GameService {
             throw new IllegalStateException("Only the host can start a new game!");
         }
 
-        Game newGame = new Game(host);
+        Game newGame = new Game().withPlayer(host);
 
         for (User playerInLobby : lobby.players()) {
             User player = userService.getUserById(playerInLobby.id());
@@ -87,7 +87,7 @@ public class GameService {
         User user = userService.getLoggedInUser(principal);
         Game game = gameRepo.findById(gameId).orElseThrow(NoSuchElementException::new);
 
-        Turn newPrompt = promptCreate.asNewPromptTurn().withPlayer(user);
+        Turn newPrompt = promptCreate.asNewPromptTurn(user);
         Game gameWithPrompt = game.withTurn(newPrompt);
 
         return gameRepo.save(gameWithPrompt).asRoundResponse(user);

--- a/backend/src/test/java/in/kahl/promptwhispers/model/GameTest.java
+++ b/backend/src/test/java/in/kahl/promptwhispers/model/GameTest.java
@@ -3,7 +3,6 @@ package in.kahl.promptwhispers.model;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -14,11 +13,11 @@ class GameTest {
     void withTurnTest_whenProvidingTurn_thenReturnGameWithTurn() {
         // ARRANGE
         User user = new User("user@example.com");
-        Game newGame = new Game(user);
-        Turn turnPrompt = new Turn(TurnType.PROMPT, "A hedge jumps over a sheep");
+        Game newGame = new Game().withPlayer(user);
+        Turn turnPrompt = new Turn(user, TurnType.PROMPT, "A hedge jumps over a sheep");
         Game gameExpected = new Game(newGame.id(),
                 newGame.players(),
-                Map.of(0, List.of(turnPrompt)),
+                List.of(List.of(turnPrompt)),
                 GameState.REQUEST_NEW_PROMPTS,
                 newGame.createdAt());
 
@@ -34,7 +33,7 @@ class GameTest {
         // ARRANGE
         User alice = new User("alice@example.com");
         User bob = new User("bob@example.com");
-        Game gameWith1Image = new Game(alice)
+        Game gameWith1Image = new Game().withPlayer(alice)
                 .withPlayer(bob)
                 .withTurn(new Turn(alice, TurnType.PROMPT, "1st prompt"))
                 .withTurn(new Turn(bob, TurnType.PROMPT, "1st prompt"))
@@ -56,7 +55,7 @@ class GameTest {
         // ARRANGE
         User alice = new User("alice@example.com");
         User bob = new User("bob@example.com");
-        Game finishedGame = new Game(alice)
+        Game finishedGame = new Game().withPlayer(alice)
                 .withPlayer(bob)
                 .withTurn(new Turn(alice, TurnType.PROMPT, "1st prompt"))
                 .withTurn(new Turn(bob, TurnType.PROMPT, "1st prompt"))

--- a/backend/src/test/java/in/kahl/promptwhispers/service/UserServiceTest.java
+++ b/backend/src/test/java/in/kahl/promptwhispers/service/UserServiceTest.java
@@ -151,8 +151,8 @@ class UserServiceTest {
     void getAllGamesTest_whenGamesExists_thenReturnGames() {
         // ARRANGE
         User testUser = new User(userEmail);
-        Game testGame1 = new Game(testUser);
-        Game testGame2 = new Game(testUser);
+        Game testGame1 = new Game().withPlayer(testUser);
+        Game testGame2 = new Game().withPlayer(testUser);
         testUser = testUser.withGame(testGame1)
                 .withGame(testGame2);
 
@@ -180,8 +180,8 @@ class UserServiceTest {
     void removeGameTest_whenGameExists_thenRemoveGame() {
         // ARRANGE
         User userExpected = new User(userEmail);
-        Game testGame1 = new Game(userExpected);
-        Game testGameToDelete = new Game(userExpected);
+        Game testGame1 = new Game().withPlayer(userExpected);
+        Game testGameToDelete = new Game().withPlayer(userExpected);
         userExpected = userExpected.withGame(testGame1);
 
         User testUser = userExpected.withGame(testGameToDelete);

--- a/frontend/src/types/Game.ts
+++ b/frontend/src/types/Game.ts
@@ -2,7 +2,7 @@ import { Turn } from "./Turn.ts";
 
 export type Game = {
   id: string;
-  rounds: { [key: number]: Turn[] };
+  rounds: Turn[][];
   createdAt: Date;
   gameState: "NEW" | "PROMPT_PHASE" | "IMAGE_PHASE" | "FINISHED";
 };


### PR DESCRIPTION
Ziel des Refaktors: Das Handling auf Frontend Seite vereinfachen.

Ich musste auch im Game Record den Konstruktor etwas refactorn, damit die Liste der Runden mit der Anzahl der hinzugefügten Spieler mitwächst. 